### PR TITLE
fix filter signature to allow params, issue in test

### DIFF
--- a/src/containers.ts
+++ b/src/containers.ts
@@ -25,7 +25,7 @@ export type HelperFunction = (
   config: SqrlConfig
 ) => string | Promise<string>
 
-export type FilterFunction = (str: string) => any | Promise<any>
+export type FilterFunction = (obj: any, ...filterParameters: any[]) => any | Promise<any>
 
 interface EscapeMap {
   '&': '&amp;'

--- a/test/filters.spec.ts
+++ b/test/filters.spec.ts
@@ -28,5 +28,14 @@ describe('Simple render checks', () => {
         '<script>Malicious XSS</script>'
       )
     })
+    it('Custom filter with parameters', () => {
+      filters.define('customFilterWithParams', function (obj: any, ...filterParameters: any[]): string {
+        const [joinStr, lastJoinStr] = filterParameters
+        const last = obj.splice(-1)
+        return obj.join(joinStr) + lastJoinStr + last;
+      })
+      expect(render(`{{ it.fruits | customFilterWithParams(', ', ' or ') /}}?`, { fruits: [1, 2, 3] }))
+      .toEqual('Banana, Kiwi or Apple?')
+    })
   })
 })


### PR DESCRIPTION
@nebrelbug I have an issue with the test I'm adding.
I was expecting to use a filter that receive an array and as obj and returns a promised string based on parameters.
Parameters are received correctly but the obj sent is string instead of array type. 
What am I missing?
