### PR TITLE
docs: fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Simply put, Squirrelly is super lightweight, super fast, super powerful, and sup
   - _ex. `{{someval + "name }}" }}`_ compiles correctly, while it fails with DoT or EJS
 - ⚡️ Exports ES Modules as well as UMD
 - 🔨 Loops
-- 🔧 Custom delimeters
+- 🔧 Custom delimiters
 - 📝 Easy template syntax
 - 🔧 Precompilation
 - 🔨 Partials


### PR DESCRIPTION
Hello,

This tiny PR will fix : 

- 1 typo in `README.md`



Bye! :robot: