### PR TITLE
[ Feature ] - Preventing null and undefined exception on template variables 

### DIFF
--- a/src/compile-string.ts
+++ b/src/compile-string.ts
@@ -111,11 +111,13 @@ export function compileScope (buff: Array<AstObject>, env: SqrlConfig) {
       // we know string exists
       returnStr += "tR+='" + str + "';"
     } else {
+      currentBlock.c = safeCompile( currentBlock.c || '', '')
+      currentBlock.p = safeCompile( currentBlock.p || '', '')
       var type: ParsedTagType = currentBlock.t as ParsedTagType // h, s, e, i
-      var content = safeCompile(currentBlock.c || '', '')
+      var content = currentBlock.c
       var filters = currentBlock.f
       var name = currentBlock.n || ''
-      var params = safeCompile(currentBlock.p || '', '')
+      var params = currentBlock.p
       var res = currentBlock.res || ''
       var blocks = currentBlock.b
       var isAsync = !!currentBlock.a // !! is to booleanize it

--- a/src/compile-string.ts
+++ b/src/compile-string.ts
@@ -1,7 +1,7 @@
 import Parse from './parse'
 
 /* TYPES */
-import { safeCompile } from './utils'
+
 import { SqrlConfig } from './config'
 import { AstObject, Filter, ParentTemplateObject } from './parse'
 type ParsedTagType = 'h' | 's' | 'e' | 'i'
@@ -9,7 +9,7 @@ type ParsedTagType = 'h' | 's' | 'e' | 'i'
 
 /* END TYPES */
 
-export default function compileToString(str: string, env: SqrlConfig) {
+export default function compileToString (str: string, env: SqrlConfig) {
   var buffer: Array<AstObject> = Parse(str, env)
 
   var res =
@@ -33,7 +33,7 @@ export default function compileToString(str: string, env: SqrlConfig) {
   // TODO: is `return cb()` necessary, or could we just do `cb()`
 }
 
-function filter(str: string, filters: Array<Filter>) {
+function filter (str: string, filters: Array<Filter>) {
   for (var i = 0; i < filters.length; i++) {
     var name = filters[i][0]
     var params = filters[i][1]
@@ -56,7 +56,7 @@ function filter(str: string, filters: Array<Filter>) {
 // TODO: Use type intersections for TemplateObject, etc.
 // so I don't have to make properties mandatory
 
-function compileHelper(
+function compileHelper (
   env: SqrlConfig,
   res: string,
   descendants: Array<AstObject>,
@@ -81,7 +81,7 @@ function compileHelper(
   return ret
 }
 
-function compileBlocks(blocks: Array<ParentTemplateObject>, env: SqrlConfig) {
+function compileBlocks (blocks: Array<ParentTemplateObject>, env: SqrlConfig) {
   var ret = '['
   for (var i = 0; i < blocks.length; i++) {
     var block = blocks[i]
@@ -94,12 +94,11 @@ function compileBlocks(blocks: Array<ParentTemplateObject>, env: SqrlConfig) {
   return ret
 }
 
-export function compileScopeIntoFunction(buff: Array<AstObject>, res: string, env: SqrlConfig) {
+export function compileScopeIntoFunction (buff: Array<AstObject>, res: string, env: SqrlConfig) {
   return 'function(' + res + "){var tR='';" + compileScope(buff, env) + 'return tR}'
 }
 
-export function compileScope(buff: Array<AstObject>, env: SqrlConfig) {
-
+export function compileScope (buff: Array<AstObject>, env: SqrlConfig) {
   var i = 0
   var buffLength = buff.length
   var returnStr = ''
@@ -108,19 +107,18 @@ export function compileScope(buff: Array<AstObject>, env: SqrlConfig) {
     var currentBlock = buff[i]
     if (typeof currentBlock === 'string') {
       var str = currentBlock
+
       // we know string exists
       returnStr += "tR+='" + str + "';"
     } else {
-      currentBlock.p = safeCompile(currentBlock.p, '') || ''
       var type: ParsedTagType = currentBlock.t as ParsedTagType // h, s, e, i
-      var content = safeCompile(currentBlock.c, '') || ''
+      var content = currentBlock.c || ''
       var filters = currentBlock.f
       var name = currentBlock.n || ''
       var params = currentBlock.p || ''
       var res = currentBlock.res || ''
       var blocks = currentBlock.b
       var isAsync = !!currentBlock.a // !! is to booleanize it
-
       // if (isAsync && !env.async) {
       //   throw SqrlErr("Async block or helper '" + name + "' in non-async env")
       // }

--- a/src/compile-string.ts
+++ b/src/compile-string.ts
@@ -1,5 +1,5 @@
 import Parse from './parse'
-
+import { safeCompile } from './utils'
 /* TYPES */
 
 import { SqrlConfig } from './config'
@@ -112,10 +112,10 @@ export function compileScope (buff: Array<AstObject>, env: SqrlConfig) {
       returnStr += "tR+='" + str + "';"
     } else {
       var type: ParsedTagType = currentBlock.t as ParsedTagType // h, s, e, i
-      var content = currentBlock.c || ''
+      var content = safeCompile(currentBlock.c || '', '')
       var filters = currentBlock.f
       var name = currentBlock.n || ''
-      var params = currentBlock.p || ''
+      var params = safeCompile(currentBlock.p || '', '')
       var res = currentBlock.res || ''
       var blocks = currentBlock.b
       var isAsync = !!currentBlock.a // !! is to booleanize it

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,6 +22,10 @@ try {
 
 export { asyncFunc }
 
+export const safeCompile = (variableName: string, returnStr: string) : string => {
+  return `(function(){ try{ return ${variableName} }catch(err) { return ${returnStr}} })()`
+}
+
 export function hasOwnProp (obj: object, prop: string) {
   return Object.prototype.hasOwnProperty.call(obj, prop)
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,7 @@ export { asyncFunc }
 export const safeCompile = (variableName: string, returnStr: string) : string => {
   return `(function(){
     try{
-      return ${variableName}? ${variableName}: ''
+      return ${variableName} == undefined || ${variableName} == null? '': ${variableName}
     }catch(err) {
       return ${returnStr}
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,7 @@ export const safeCompile = (variableName: string, returnStr: string) : string =>
     try{
       return ${variableName} == undefined || ${variableName} == null? '': ${variableName}
     }catch(err) {
-      return ${returnStr}
+      return ''
     }
   })()`
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,7 +23,13 @@ try {
 export { asyncFunc }
 
 export const safeCompile = (variableName: string, returnStr: string) : string => {
-  return `(function(){ try{ return ${variableName} }catch(err) { return ${returnStr}} })()`
+  return `(function(){
+    try{
+      return ${variableName}? ${variableName}: ${returnStr}
+    }catch(err) {
+      return ${returnStr}
+    }
+  })()`
 }
 
 export function hasOwnProp (obj: object, prop: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,17 +20,13 @@ try {
   }
 }
 
-export const safeCompile = (a: any, b: any) => {
-  return `(function(){ try{ return ${a} }catch(err) { return ${b}} })()`
-}
-
 export { asyncFunc }
 
-export function hasOwnProp(obj: object, prop: string) {
+export function hasOwnProp (obj: object, prop: string) {
   return Object.prototype.hasOwnProperty.call(obj, prop)
 }
 
-export function copyProps<T>(toObj: T, fromObj: T, notConfig?: boolean) {
+export function copyProps<T> (toObj: T, fromObj: T, notConfig?: boolean) {
   for (var key in fromObj) {
     if (hasOwnProp((fromObj as unknown) as object, key)) {
       if (
@@ -52,7 +48,7 @@ export function copyProps<T>(toObj: T, fromObj: T, notConfig?: boolean) {
   return toObj
 }
 
-function trimWS(
+function trimWS (
   str: string,
   env: SqrlConfig,
   wsLeft: string | false,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,13 +20,17 @@ try {
   }
 }
 
+export const safeCompile = (a: any, b: any) => {
+  return `(function(){ try{ return ${a} }catch(err) { return ${b}} })()`
+}
+
 export { asyncFunc }
 
-export function hasOwnProp (obj: object, prop: string) {
+export function hasOwnProp(obj: object, prop: string) {
   return Object.prototype.hasOwnProperty.call(obj, prop)
 }
 
-export function copyProps<T> (toObj: T, fromObj: T, notConfig?: boolean) {
+export function copyProps<T>(toObj: T, fromObj: T, notConfig?: boolean) {
   for (var key in fromObj) {
     if (hasOwnProp((fromObj as unknown) as object, key)) {
       if (
@@ -48,7 +52,7 @@ export function copyProps<T> (toObj: T, fromObj: T, notConfig?: boolean) {
   return toObj
 }
 
-function trimWS (
+function trimWS(
   str: string,
   env: SqrlConfig,
   wsLeft: string | false,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,7 @@ export { asyncFunc }
 export const safeCompile = (variableName: string, returnStr: string) : string => {
   return `(function(){
     try{
-      return ${variableName}? ${variableName}: ${returnStr}
+      return ${variableName}? ${variableName}: ''
     }catch(err) {
       return ${returnStr}
     }


### PR DESCRIPTION
Hi All! 
First of all, thanks for this amazing project, I was looking for something like this to use in my web component library, called Jails, you can find more info here: https://github.com/jails-org/Jails

## The Problem
This PR tries to solve a problem that was making it impossible to use in my project, which is the fact that you might not have a variable already set used on iteration and conditions, so on those cases it breaks the entire application instead of returning null or false. I believe that Mustache already have this behavior by default, if you try to use some variable that doesn't exist it just skip it and treat as a falsy / empty value.

## The Solution 
try/catch is the only solution I've could think to solve that problem, so I wrap all variables with a function that tries to return that variable if it is set and return an empty string otherwise.

---
I didn't have time to look for all edge cases and I still not familiar with the entire code, and I'm not sure how much it's going to impact on performance, so maybe there's a better way, but I'll be glad if my PR could be usefull somehow even if it can't be merged.

Thanks in advance! Have a good one.
