### PR TITLE
[security] Don't use data object for Squirrelly configuration

### DIFF
--- a/src/file-handlers.ts
+++ b/src/file-handlers.ts
@@ -18,9 +18,6 @@ interface FileOptions extends SqrlConfig {
 }
 
 interface DataObj {
-  settings?: {
-    [key: string]: any
-  }
   [key: string]: any
 }
 
@@ -113,16 +110,6 @@ function renderFile (filename: string, data: DataObj, cb?: CallbackFn) {
   data = data || {}
   var Config: FileOptions = getConfig((data as PartialConfig)) as FileOptions
   // TODO: make sure above doesn't error. We do set filename down below
-
-  if (data.settings) {
-    // Pull a few things from known locations
-    if (data.settings.views) {
-      Config.views = data.settings.views
-    }
-    if (data.settings['view cache']) {
-      Config.cache = true
-    }
-  }
 
   Config.filename = filename // Make sure filename is right
 

--- a/src/file-handlers.ts
+++ b/src/file-handlers.ts
@@ -4,7 +4,7 @@ import SqrlErr from './err'
 import compile from './compile'
 import { getConfig } from './config'
 import { getPath, readFile, loadFile } from './file-utils'
-import { promiseImpl, copyProps } from './utils'
+import { promiseImpl } from './utils'
 
 /* TYPES */
 
@@ -34,7 +34,6 @@ interface DataObj {
  * `options.filename` so it must be set prior to calling this function.
  *
  * @param {Options} options   compilation options
- * @param {String} [template] template source
  * @return {(TemplateFunction|ClientFunction)}
  * Depending on the value of `options.client`, either type might be returned.
  * @static
@@ -122,13 +121,6 @@ function renderFile (filename: string, data: DataObj, cb?: CallbackFn) {
     }
     if (data.settings['view cache']) {
       Config.cache = true
-    }
-    // Undocumented after Express 2, but still usable, esp. for
-    // items that are unsafe to be passed along with data, like `root`
-    var viewOpts = data.settings['view options']
-
-    if (viewOpts) {
-      copyProps(Config, viewOpts)
     }
   }
 


### PR DESCRIPTION
It would be really great if Squirrelly released a fix for https://github.com/advisories/GHSA-q8j6-pwqx-pm96.

This is an attempt at porting over the corresponding fix from https://github.com/eta-dev/eta/pull/214

Reported in #238

https://github.com/eta-dev/eta/releases/tag/v2.0.0