### PR TITLE
Fix defaultFilter code injection

### DIFF
--- a/src/compile-string.ts
+++ b/src/compile-string.ts
@@ -125,7 +125,7 @@ export function compileScope (buff: Array<AstObject>, env: SqrlConfig) {
       // Let compiler do this
       if (type === 'i') {
         if (env.defaultFilter) {
-          content = "c.l('F','" + env.defaultFilter + "')(" + content + ')'
+          content = "c.l('F'," + JSON.stringify(env.defaultFilter) + ')(' + content + ')'
         }
         var filtered = filter(content, filters)
         if (!currentBlock.raw && env.autoEscape) {

--- a/test/compile-string.spec.ts
+++ b/test/compile-string.spec.ts
@@ -37,7 +37,7 @@ describe('Compile to String test', () => {
       getConfig({ defaultFilter: 'filter1', autoEscape: false })
     )
     expect(str).toEqual(
-      "var tR='';tR+='hi ';tR+=c.l('F','filter1')(hey);if(cb){cb(null,tR)} return tR"
+      "var tR='';tR+='hi ';tR+=c.l('F',\"filter1\")(hey);if(cb){cb(null,tR)} return tR"
     )
   })
 

--- a/test/filters.spec.ts
+++ b/test/filters.spec.ts
@@ -28,5 +28,15 @@ describe('Simple render checks', () => {
         '<script>Malicious XSS</script>'
       )
     })
+    it('Does not execute code from default filter names', () => {
+      var globalWithInjected = global as typeof global & { sqrlDefaultFilterInjected?: boolean }
+      globalWithInjected.sqrlDefaultFilterInjected = false
+      var payload = "e')(), global.sqrlDefaultFilterInjected=true, c.l('F','e"
+
+      expect(() =>
+        render('{{it.name}}', { name: 'Ada Lovelace' }, { defaultFilter: payload })
+      ).toThrow("Can't find filter")
+      expect(globalWithInjected.sqrlDefaultFilterInjected).toBe(false)
+    })
   })
 })


### PR DESCRIPTION
## Summary
- serialize `defaultFilter` with `JSON.stringify` before embedding it in generated function source
- update the compile-string expectation for the generated filter lookup
- add a regression test that malicious `defaultFilter` text is treated as a filter name and does not execute

## Testing
- `npx jest test/compile-string.spec.ts test/filters.spec.ts --runInBand --no-cache`
- `npm test -- --runInBand --no-cache`
- `npm run lint` (passes with existing warnings)

## Notes
- `npm run build` currently gets through Rollup, then fails in TypeDoc while parsing `node_modules/@types/babel__traverse/index.d.ts` with the repo's pinned TypeScript 4.0.8.